### PR TITLE
Allow the `mandatory` option in the field configuration

### DIFF
--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -15,6 +15,7 @@
  * Additions tl_form_field
  */
 $GLOBALS['TL_DCA']['tl_form_field']['palettes']['signature'] = '{type_legend},type,name,label;'
+                                                              .'{fconfig_legend},mandatory;'
                                                               .'{size_legend},sig_size;'
                                                               .'{expert_legend:hide},class,sig_bgcolor,sig_color,sig_width;'
                                                               .'{template_legend:hide},customTpl;'


### PR DESCRIPTION
In case the form has to have the signature, the field has to be validated. Only the activation of the field configuration is necessary. The rest is already in.